### PR TITLE
Use instance variables for request/response data.

### DIFF
--- a/lib/facebook/messenger/server.rb
+++ b/lib/facebook/messenger/server.rb
@@ -6,48 +6,46 @@ module Facebook
     # This module holds the server that processes incoming messages from the
     # Facebook Messenger Platform.
     class Server
-      class << self
-        def call(env)
-          @request = Rack::Request.new(env)
-          @response = Rack::Response.new
+      def self.call(env)
+        new.call(env)
+      end
 
-          case @request.request_method
-          when 'GET' then verify
-          when 'POST' then receive
-          else method_not_allowed
-          end
+      def call(env)
+        @request = Rack::Request.new(env)
+        @response = Rack::Response.new
+
+        case
+        when @request.get? then verify
+        when @request.post? then receive
+        else @response.status = 405
         end
 
-        def verify
-          verify_token = Facebook::Messenger.config.verify_token
+        @response.finish
+      end
 
-          if @request.params['hub.verify_token'] == verify_token
-            @response.write @request.params['hub.challenge']
-          else
-            @response.write 'Error; wrong verify token'
-          end
-
-          @response.finish
+      def verify
+        if @request['hub.verify_token'] == verify_token
+          @response.write @request['hub.challenge']
+        else
+          @response.write 'Error; wrong verify token'
         end
+      end
 
-        def receive
-          hash = JSON.parse(@request.body.read)
-          # Facebook may batch several items in the 'entry' array during
+      def verify_token
+        Facebook::Messenger.config.verify_token
+      end
+
+      def receive
+        hash = JSON.parse(@request.body.read)
+
+        # Facebook may batch several items in the 'entry' array during
+        # periods of high load.
+        hash['entry'].each do |entry|
+          # Facebook may batch several items in the 'messaging' array during
           # periods of high load.
-          hash['entry'].each do |entry|
-            # Facebook may batch several items in the 'messaging' array during
-            # periods of high load.
-            entry['messaging'].each do |messaging|
-              Facebook::Messenger::Bot.receive(messaging)
-            end
+          entry['messaging'].each do |messaging|
+            Facebook::Messenger::Bot.receive(messaging)
           end
-
-          @response.finish
-        end
-
-        def method_not_allowed
-          @response.status = 405
-          @response.finish
         end
       end
     end


### PR DESCRIPTION
I think this would be more friendly for threaded
servers. I don't think request/response data should
be shared.