### PR TITLE
fix typo in readme which incorrectly includes the production environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ reference constants. You'll need to explicitly load `app/bot`, then:
 
 ```ruby
 # config/initializers/bot.rb
-if Rails.env.production?
+unless Rails.env.production?
   Dir["#{Rails.root}/app/bot/**/*.rb"].each { |file| require file }
 end
 ```


### PR DESCRIPTION
I think there is a typo in the readme which confused me for a while