### PR TITLE
Support Rack 2

### DIFF
--- a/facebook-messenger.gemspec
+++ b/facebook-messenger.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'httparty', '~> 0.13.7'
-  spec.add_runtime_dependency 'rack', '~> 1.6.4'
+  spec.add_runtime_dependency 'rack', '=> 1.6.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rspec', '~> 3.4'


### PR DESCRIPTION
We're using Rails 5 which requires rack 2. facebook-messenger works like a charm on rack2!