### PR TITLE
Make incomings payloads public

### DIFF
--- a/lib/facebook/messenger/incoming/delivery.rb
+++ b/lib/facebook/messenger/incoming/delivery.rb
@@ -4,30 +4,30 @@ module Facebook
       # The Delivery class represents the receipt of a delivered message.
       class Delivery
 
-        attr_reader :payload
+        attr_reader :raw_payload
 
-        def initialize(payload)
-          @payload = payload
+        def initialize(raw_payload)
+          @raw_payload = raw_payload
         end
 
         def ids
-          @payload['delivery']['mids']
+          @raw_payload['delivery']['mids']
         end
 
         def at
-          Time.at(@payload['delivery']['watermark'] / 1000)
+          Time.at(@raw_payload['delivery']['watermark'] / 1000)
         end
 
         def seq
-          @payload['delivery']['seq']
+          @raw_payload['delivery']['seq']
         end
 
         def sender
-          @payload['sender']
+          @raw_payload['sender']
         end
 
         def recipient
-          @payload['recipient']
+          @raw_payload['recipient']
         end
       end
     end

--- a/lib/facebook/messenger/incoming/delivery.rb
+++ b/lib/facebook/messenger/incoming/delivery.rb
@@ -3,7 +3,6 @@ module Facebook
     module Incoming
       # The Delivery class represents the receipt of a delivered message.
       class Delivery
-
         attr_reader :messaging
 
         def initialize(messaging)

--- a/lib/facebook/messenger/incoming/delivery.rb
+++ b/lib/facebook/messenger/incoming/delivery.rb
@@ -3,6 +3,9 @@ module Facebook
     module Incoming
       # The Delivery class represents the receipt of a delivered message.
       class Delivery
+
+        attr_reader :payload
+
         def initialize(payload)
           @payload = payload
         end

--- a/lib/facebook/messenger/incoming/delivery.rb
+++ b/lib/facebook/messenger/incoming/delivery.rb
@@ -4,30 +4,30 @@ module Facebook
       # The Delivery class represents the receipt of a delivered message.
       class Delivery
 
-        attr_reader :raw_payload
+        attr_reader :messaging
 
-        def initialize(raw_payload)
-          @raw_payload = raw_payload
+        def initialize(messaging)
+          @messaging = messaging
         end
 
         def ids
-          @raw_payload['delivery']['mids']
+          @messaging['delivery']['mids']
         end
 
         def at
-          Time.at(@raw_payload['delivery']['watermark'] / 1000)
+          Time.at(@messaging['delivery']['watermark'] / 1000)
         end
 
         def seq
-          @raw_payload['delivery']['seq']
+          @messaging['delivery']['seq']
         end
 
         def sender
-          @raw_payload['sender']
+          @messaging['sender']
         end
 
         def recipient
-          @raw_payload['recipient']
+          @messaging['recipient']
         end
       end
     end

--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -4,30 +4,30 @@ module Facebook
       # The Message class represents an incoming Facebook Messenger message.
       class Message
 
-        attr_reader :payload
+        attr_reader :raw_payload
 
-        def initialize(payload)
-          @payload = payload
+        def initialize(raw_payload)
+          @raw_payload = raw_payload
         end
 
         def id
-          @payload['message']['mid']
+          @raw_payload['message']['mid']
         end
 
         def sender
-          @payload['sender']
+          @raw_payload['sender']
         end
 
         def seq
-          @payload['message']['seq']
+          @raw_payload['message']['seq']
         end
 
         def sent_at
-          Time.at(@payload['timestamp'] / 1000)
+          Time.at(@raw_payload['timestamp'] / 1000)
         end
 
         def text
-          @payload['message']['text']
+          @raw_payload['message']['text']
         end
       end
     end

--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -3,7 +3,6 @@ module Facebook
     module Incoming
       # The Message class represents an incoming Facebook Messenger message.
       class Message
-
         attr_reader :messaging
 
         def initialize(messaging)

--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -4,30 +4,30 @@ module Facebook
       # The Message class represents an incoming Facebook Messenger message.
       class Message
 
-        attr_reader :raw_payload
+        attr_reader :messaging
 
-        def initialize(raw_payload)
-          @raw_payload = raw_payload
+        def initialize(messaging)
+          @messaging = messaging
         end
 
         def id
-          @raw_payload['message']['mid']
+          @messaging['message']['mid']
         end
 
         def sender
-          @raw_payload['sender']
+          @messaging['sender']
         end
 
         def seq
-          @raw_payload['message']['seq']
+          @messaging['message']['seq']
         end
 
         def sent_at
-          Time.at(@raw_payload['timestamp'] / 1000)
+          Time.at(@messaging['timestamp'] / 1000)
         end
 
         def text
-          @raw_payload['message']['text']
+          @messaging['message']['text']
         end
       end
     end

--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -3,6 +3,9 @@ module Facebook
     module Incoming
       # The Message class represents an incoming Facebook Messenger message.
       class Message
+
+        attr_reader :payload
+
         def initialize(payload)
           @payload = payload
         end

--- a/lib/facebook/messenger/incoming/optin.rb
+++ b/lib/facebook/messenger/incoming/optin.rb
@@ -7,26 +7,26 @@ module Facebook
       # https://developers.facebook.com/docs/messenger-platform/plugin-reference
       class Optin
 
-        attr_reader :raw_payload
+        attr_reader :messaging
 
-        def initialize(raw_payload)
-          @raw_payload = raw_payload
+        def initialize(messaging)
+          @messaging = messaging
         end
 
         def sender
-          @raw_payload['sender']
+          @messaging['sender']
         end
 
         def recipient
-          @raw_payload['recipient']
+          @messaging['recipient']
         end
 
         def sent_at
-          Time.at(@raw_payload['timestamp'] / 1000)
+          Time.at(@messaging['timestamp'] / 1000)
         end
 
         def ref
-          @raw_payload['optin']['ref']
+          @messaging['optin']['ref']
         end
       end
     end

--- a/lib/facebook/messenger/incoming/optin.rb
+++ b/lib/facebook/messenger/incoming/optin.rb
@@ -6,6 +6,9 @@ module Facebook
       #
       # https://developers.facebook.com/docs/messenger-platform/plugin-reference
       class Optin
+
+        attr_reader :payload
+
         def initialize(payload)
           @payload = payload
         end

--- a/lib/facebook/messenger/incoming/optin.rb
+++ b/lib/facebook/messenger/incoming/optin.rb
@@ -7,26 +7,26 @@ module Facebook
       # https://developers.facebook.com/docs/messenger-platform/plugin-reference
       class Optin
 
-        attr_reader :payload
+        attr_reader :raw_payload
 
-        def initialize(payload)
-          @payload = payload
+        def initialize(raw_payload)
+          @raw_payload = raw_payload
         end
 
         def sender
-          @payload['sender']
+          @raw_payload['sender']
         end
 
         def recipient
-          @payload['recipient']
+          @raw_payload['recipient']
         end
 
         def sent_at
-          Time.at(@payload['timestamp'] / 1000)
+          Time.at(@raw_payload['timestamp'] / 1000)
         end
 
         def ref
-          @payload['optin']['ref']
+          @raw_payload['optin']['ref']
         end
       end
     end

--- a/lib/facebook/messenger/incoming/optin.rb
+++ b/lib/facebook/messenger/incoming/optin.rb
@@ -6,7 +6,6 @@ module Facebook
       #
       # https://developers.facebook.com/docs/messenger-platform/plugin-reference
       class Optin
-
         attr_reader :messaging
 
         def initialize(messaging)

--- a/lib/facebook/messenger/incoming/postback.rb
+++ b/lib/facebook/messenger/incoming/postback.rb
@@ -4,26 +4,26 @@ module Facebook
       # The Postback class represents an incoming Facebook Messenger postback.
       class Postback
 
-        attr_reader :payload
+        attr_reader :raw_payload
 
-        def initialize(payload)
-          @payload = payload
+        def initialize(raw_payload)
+          @raw_payload = raw_payload
         end
 
         def sender
-          @payload['sender']
+          @raw_payload['sender']
         end
 
         def recipient
-          @payload['recipient']
+          @raw_payload['recipient']
         end
 
         def sent_at
-          Time.at(@payload['timestamp'] / 1000)
+          Time.at(@raw_payload['timestamp'] / 1000)
         end
 
         def payload
-          @payload['postback']['payload']
+          @raw_payload['postback']['payload']
         end
       end
     end

--- a/lib/facebook/messenger/incoming/postback.rb
+++ b/lib/facebook/messenger/incoming/postback.rb
@@ -3,7 +3,6 @@ module Facebook
     module Incoming
       # The Postback class represents an incoming Facebook Messenger postback.
       class Postback
-
         attr_reader :messaging
 
         def initialize(messaging)

--- a/lib/facebook/messenger/incoming/postback.rb
+++ b/lib/facebook/messenger/incoming/postback.rb
@@ -3,6 +3,9 @@ module Facebook
     module Incoming
       # The Postback class represents an incoming Facebook Messenger postback.
       class Postback
+
+        attr_reader :payload
+
         def initialize(payload)
           @payload = payload
         end

--- a/lib/facebook/messenger/incoming/postback.rb
+++ b/lib/facebook/messenger/incoming/postback.rb
@@ -4,26 +4,26 @@ module Facebook
       # The Postback class represents an incoming Facebook Messenger postback.
       class Postback
 
-        attr_reader :raw_payload
+        attr_reader :messaging
 
-        def initialize(raw_payload)
-          @raw_payload = raw_payload
+        def initialize(messaging)
+          @messaging = messaging
         end
 
         def sender
-          @raw_payload['sender']
+          @messaging['sender']
         end
 
         def recipient
-          @raw_payload['recipient']
+          @messaging['recipient']
         end
 
         def sent_at
-          Time.at(@raw_payload['timestamp'] / 1000)
+          Time.at(@messaging['timestamp'] / 1000)
         end
 
         def payload
-          @raw_payload['postback']['payload']
+          @messaging['postback']['payload']
         end
       end
     end

--- a/spec/facebook/messenger/incoming/delivery_spec.rb
+++ b/spec/facebook/messenger/incoming/delivery_spec.rb
@@ -22,9 +22,9 @@ describe Facebook::Messenger::Incoming::Delivery do
 
   subject { Facebook::Messenger::Incoming::Delivery.new(payload) }
 
-  describe '.raw_payload' do
+  describe '.messaging' do
     it 'returns the original payload' do
-      expect(subject.raw_payload).to eq(payload)
+      expect(subject.messaging).to eq(payload)
     end
   end
 

--- a/spec/facebook/messenger/incoming/delivery_spec.rb
+++ b/spec/facebook/messenger/incoming/delivery_spec.rb
@@ -22,6 +22,12 @@ describe Facebook::Messenger::Incoming::Delivery do
 
   subject { Facebook::Messenger::Incoming::Delivery.new(payload) }
 
+  describe '.payload' do
+    it 'returns the original payload' do
+      expect(subject.payload).to eq(payload)
+    end
+  end
+
   describe '.ids' do
     it 'returns the message ids' do
       expect(subject.ids).to eq(payload['delivery']['mids'])

--- a/spec/facebook/messenger/incoming/delivery_spec.rb
+++ b/spec/facebook/messenger/incoming/delivery_spec.rb
@@ -22,9 +22,9 @@ describe Facebook::Messenger::Incoming::Delivery do
 
   subject { Facebook::Messenger::Incoming::Delivery.new(payload) }
 
-  describe '.payload' do
+  describe '.raw_payload' do
     it 'returns the original payload' do
-      expect(subject.payload).to eq(payload)
+      expect(subject.raw_payload).to eq(payload)
     end
   end
 

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -20,6 +20,12 @@ describe Facebook::Messenger::Incoming::Message do
 
   subject { Facebook::Messenger::Incoming::Message.new(payload) }
 
+  describe '.payload' do
+    it 'returns the original payload' do
+      expect(subject.payload).to eq(payload)
+    end
+  end
+
   describe '.id' do
     it 'returns the message id' do
       expect(subject.id).to eq(payload['message']['mid'])

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -20,9 +20,9 @@ describe Facebook::Messenger::Incoming::Message do
 
   subject { Facebook::Messenger::Incoming::Message.new(payload) }
 
-  describe '.raw_payload' do
+  describe '.messaging' do
     it 'returns the original payload' do
-      expect(subject.raw_payload).to eq(payload)
+      expect(subject.messaging).to eq(payload)
     end
   end
 

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -20,9 +20,9 @@ describe Facebook::Messenger::Incoming::Message do
 
   subject { Facebook::Messenger::Incoming::Message.new(payload) }
 
-  describe '.payload' do
+  describe '.raw_payload' do
     it 'returns the original payload' do
-      expect(subject.payload).to eq(payload)
+      expect(subject.raw_payload).to eq(payload)
     end
   end
 

--- a/spec/facebook/messenger/incoming/optin_spec.rb
+++ b/spec/facebook/messenger/incoming/optin_spec.rb
@@ -18,9 +18,9 @@ describe Facebook::Messenger::Incoming::Optin do
 
   subject { Facebook::Messenger::Incoming::Optin.new(payload) }
 
-  describe '.raw_payload' do
+  describe '.messaging' do
     it 'returns the original payload' do
-      expect(subject.raw_payload).to eq(payload)
+      expect(subject.messaging).to eq(payload)
     end
   end
 

--- a/spec/facebook/messenger/incoming/optin_spec.rb
+++ b/spec/facebook/messenger/incoming/optin_spec.rb
@@ -18,6 +18,12 @@ describe Facebook::Messenger::Incoming::Optin do
 
   subject { Facebook::Messenger::Incoming::Optin.new(payload) }
 
+  describe '.payload' do
+    it 'returns the original payload' do
+      expect(subject.payload).to eq(payload)
+    end
+  end
+
   describe '.sender' do
     it 'returns the sender' do
       expect(subject.sender).to eq(payload['sender'])

--- a/spec/facebook/messenger/incoming/optin_spec.rb
+++ b/spec/facebook/messenger/incoming/optin_spec.rb
@@ -18,9 +18,9 @@ describe Facebook::Messenger::Incoming::Optin do
 
   subject { Facebook::Messenger::Incoming::Optin.new(payload) }
 
-  describe '.payload' do
+  describe '.raw_payload' do
     it 'returns the original payload' do
-      expect(subject.payload).to eq(payload)
+      expect(subject.raw_payload).to eq(payload)
     end
   end
 

--- a/spec/facebook/messenger/incoming/postback_spec.rb
+++ b/spec/facebook/messenger/incoming/postback_spec.rb
@@ -18,6 +18,12 @@ describe Facebook::Messenger::Incoming::Postback do
 
   subject { Facebook::Messenger::Incoming::Postback.new(payload) }
 
+  describe '.payload' do
+    it 'returns the original payload' do
+      expect(subject.payload).to eq(payload)
+    end
+  end
+
   describe '.sender' do
     it 'returns the sender' do
       expect(subject.sender).to eq(payload['sender'])

--- a/spec/facebook/messenger/incoming/postback_spec.rb
+++ b/spec/facebook/messenger/incoming/postback_spec.rb
@@ -18,9 +18,9 @@ describe Facebook::Messenger::Incoming::Postback do
 
   subject { Facebook::Messenger::Incoming::Postback.new(payload) }
 
-  describe '.payload' do
+  describe '.raw_payload' do
     it 'returns the original payload' do
-      expect(subject.payload).to eq(payload)
+      expect(subject.raw_payload).to eq(payload)
     end
   end
 

--- a/spec/facebook/messenger/incoming/postback_spec.rb
+++ b/spec/facebook/messenger/incoming/postback_spec.rb
@@ -18,9 +18,9 @@ describe Facebook::Messenger::Incoming::Postback do
 
   subject { Facebook::Messenger::Incoming::Postback.new(payload) }
 
-  describe '.raw_payload' do
+  describe '.messaging' do
     it 'returns the original payload' do
-      expect(subject.raw_payload).to eq(payload)
+      expect(subject.messaging).to eq(payload)
     end
   end
 


### PR DESCRIPTION
Hello friends!

In order to process messages asynchronously, I want to store their `payload` in a queue. In this PR, I make the `@payload` instance variable public.

It however conflicts with the existing `Postback#payload` method.

How would you like to go about that?

1. Rename `@payload` to `@raw_payload` ?
2. Rename `Postback#payload` to `Postback#fb_payload`?
3. ... ?