### PR TITLE
Add read receipt message type

### DIFF
--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -52,6 +52,7 @@ module Facebook
           when Incoming::Delivery then trigger(:delivery, callback)
           when Incoming::Postback then trigger(:postback, callback)
           when Incoming::Optin then trigger(:optin, callback)
+          when Incoming::Read then trigger(:read, callback)
           end
         end
 

--- a/lib/facebook/messenger/incoming.rb
+++ b/lib/facebook/messenger/incoming.rb
@@ -14,7 +14,7 @@ module Facebook
         'delivery' => Delivery,
         'postback' => Postback,
         'optin' => Optin,
-        'read' => Read,
+        'read' => Read
       }.freeze
 
       # Parse the given payload.

--- a/lib/facebook/messenger/incoming.rb
+++ b/lib/facebook/messenger/incoming.rb
@@ -2,6 +2,7 @@ require 'facebook/messenger/incoming/message'
 require 'facebook/messenger/incoming/delivery'
 require 'facebook/messenger/incoming/postback'
 require 'facebook/messenger/incoming/optin'
+require 'facebook/messenger/incoming/read'
 
 module Facebook
   module Messenger
@@ -12,7 +13,8 @@ module Facebook
         'message' => Message,
         'delivery' => Delivery,
         'postback' => Postback,
-        'optin' => Optin
+        'optin' => Optin,
+        'read' => Read,
       }.freeze
 
       # Parse the given payload.

--- a/lib/facebook/messenger/incoming/read.rb
+++ b/lib/facebook/messenger/incoming/read.rb
@@ -1,0 +1,30 @@
+module Facebook
+  module Messenger
+    module Incoming
+      # The Read class represents the user reading a delivered message.
+      class Read
+        attr_reader :messaging
+
+        def initialize(messaging)
+          @messaging = messaging
+        end
+
+        def at
+          Time.at(@messaging['read']['watermark'] / 1000)
+        end
+
+        def seq
+          @messaging['read']['seq']
+        end
+
+        def sender
+          @messaging['sender']
+        end
+
+        def recipient
+          @messaging['recipient']
+        end
+      end
+    end
+  end
+end

--- a/spec/facebook/messenger/bot_spec.rb
+++ b/spec/facebook/messenger/bot_spec.rb
@@ -87,6 +87,20 @@ describe Facebook::Messenger::Bot do
         subject.receive({})
       end
     end
+
+    context 'with a read' do
+      let(:read) { Facebook::Messenger::Incoming::Read.new({}) }
+
+      it 'triggers a :read' do
+        expect(Facebook::Messenger::Incoming).to receive(:parse)
+          .and_return(read)
+
+        expect(Facebook::Messenger::Bot).to receive(:trigger)
+          .with(:read, read)
+
+        subject.receive({})
+      end
+    end
   end
 
   describe '.trigger' do


### PR DESCRIPTION
I have no idea why this started happening, but Facebook started sending me `messaging` payloads that look like this:

```
{"sender"=>{...}, "recipient"=>{...}, "timestamp"=>1465354035944, "read"=>{"watermark"=>1465354034142, "seq"=>33}}
```

which raises an `UnknownPayload` and breaks my app 😱. This behaviour doesn't appear to be documented by Facebook yet.

This PR adds support for this new type of payload.