### PR TITLE
Read was never working

### DIFF
--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -6,7 +6,7 @@ module Facebook
 
       base_uri 'https://graph.facebook.com/v2.6/me'
 
-      EVENTS = [:message, :delivery, :postback, :optin].freeze
+      EVENTS = [:message, :delivery, :postback, :optin, :read].freeze
 
       class << self
         # Deliver a message with the given payload.

--- a/spec/facebook/messenger/incoming/read_spec.rb
+++ b/spec/facebook/messenger/incoming/read_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Facebook::Messenger::Incoming::Read do
+  let :payload do
+    {
+      'sender' => {
+        'id' => '3'
+      },
+      'recipient' => {
+        'id' => '3'
+      },
+      'timestamp' => 145_776_419_762_7,
+      'read' => {
+        'watermark' => 145_866_885_625_3,
+        'seq' => 38
+      }
+    }
+  end
+
+  subject { Facebook::Messenger::Incoming::Read.new(payload) }
+
+  describe '.messaging' do
+    it 'returns the original payload' do
+      expect(subject.messaging).to eq(payload)
+    end
+  end
+
+  describe '.sender' do
+    it 'returns the sender' do
+      expect(subject.sender).to eq(payload['sender'])
+    end
+  end
+
+  describe '.recipient' do
+    it 'returns the recipient' do
+      expect(subject.recipient).to eq(payload['recipient'])
+    end
+  end
+
+  describe '.at' do
+    it 'returns when the message was read' do
+      expect(subject.at).to eq(Time.at(payload['read']['watermark'] / 1000))
+    end
+  end
+
+  describe '.seq' do
+    it 'returns the read sequence number' do
+      expect(subject.seq).to eq(payload['read']['seq'])
+    end
+  end
+end

--- a/spec/facebook/messenger/incoming_spec.rb
+++ b/spec/facebook/messenger/incoming_spec.rb
@@ -113,5 +113,29 @@ describe Facebook::Messenger::Incoming do
         )
       end
     end
+
+    context 'when the payload is a read' do
+      let :payload do
+        {
+          'sender' => {
+            'id' => '3'
+          },
+          'recipient' => {
+            'id' => '3'
+          },
+          'timestamp' => 145_776_419_762_7,
+          'read' => {
+            'watermark' => 145_866_885_625_3,
+            'seq' => 38
+          }
+        }
+      end
+
+      it 'returns an Incoming::Read' do
+        expect(subject.parse(payload)).to be_a(
+          Facebook::Messenger::Incoming::Read
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
The changes in #41 were supposed to add support to read payloads. But it actually never worked because read wasn't added to the list of events which can be passed to `Bot.on`. Doing `Bot.on :read` was generating the error `/gems/facebook-messenger-0.8.0/lib/facebook/messenger/bot.rb:34:in `on': read is not a valid event; available events are message,delivery,postback,optin (ArgumentError)`.

This pull request fixes it. It also adds more unit tests.