### PR TITLE
Improve README for Rails to reload app/bot/**/*.rb files

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,15 +312,15 @@ reference constants. You'll need to explicitly load `app/bot`, then:
 ```ruby
 # config/initializers/bot.rb
 unless Rails.env.production?
-  api_files = Dir[Rails.root.join('app', 'bot', '**', '*.rb')]
-  api_reloader = ActiveSupport::FileUpdateChecker.new(api_files) do
-    api_files.each{ |file| require_dependency file }
+  bot_files = Dir[Rails.root.join('app', 'bot', '**', '*.rb')]
+  bot_reloader = ActiveSupport::FileUpdateChecker.new(bot_files) do
+    bot_files.each{ |file| require_dependency file }
   end
   ActionDispatch::Callbacks.to_prepare do
-    api_reloader.execute_if_updated
+    bot_reloader.execute_if_updated
   end
 
-  api_files.each { |file| require_dependency file }
+  bot_files.each { |file| require_dependency file }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,14 @@ unless Rails.env.production?
 end
 ```
 
+And add below code into `config/application.rb` to ensure rails knows bot files.
+
+```ruby
+# Auto-load bots and its subdirectories
+config.paths.add File.join('app', 'bots'), glob: File.join('**', '*.rb')
+config.autoload_paths += Dir[Rails.root.join('app', 'bots', '*')]
+```
+
 To test your locally running bot, you can use [ngrok]. This will create a secure
 tunnel to localhost so that Facebook can reach the webhook.
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,15 @@ reference constants. You'll need to explicitly load `app/bot`, then:
 ```ruby
 # config/initializers/bot.rb
 unless Rails.env.production?
-  Dir["#{Rails.root}/app/bot/**/*.rb"].each { |file| require file }
+  api_files = Dir[Rails.root.join('app', 'bot', '**', '*.rb')]
+  api_reloader = ActiveSupport::FileUpdateChecker.new(api_files) do
+    api_files.each{ |file| require_dependency file }
+  end
+  ActionDispatch::Callbacks.to_prepare do
+    api_reloader.execute_if_updated
+  end
+
+  api_files.each { |file| require_dependency file }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -312,15 +312,15 @@ reference constants. You'll need to explicitly load `app/bot`, then:
 ```ruby
 # config/initializers/bot.rb
 unless Rails.env.production?
-  bots_files = Dir[Rails.root.join('app', 'bot', '**', '*.rb')]
-  bots_reloader = ActiveSupport::FileUpdateChecker.new(bots_files) do
-    bots_files.each{ |file| require_dependency file }
+  bot_files = Dir[Rails.root.join('app', 'bots', '**', '*.rb')]
+  bot_reloader = ActiveSupport::FileUpdateChecker.new(bot_files) do
+    bot_files.each{ |file| require_dependency file }
   end
   ActionDispatch::Callbacks.to_prepare do
     bot_reloader.execute_if_updated
   end
 
-  bots_files.each { |file| require_dependency file }
+  bot_files.each { |file| require_dependency file }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -312,15 +312,15 @@ reference constants. You'll need to explicitly load `app/bot`, then:
 ```ruby
 # config/initializers/bot.rb
 unless Rails.env.production?
-  bot_files = Dir[Rails.root.join('app', 'bot', '**', '*.rb')]
-  bot_reloader = ActiveSupport::FileUpdateChecker.new(bot_files) do
-    bot_files.each{ |file| require_dependency file }
+  bots_files = Dir[Rails.root.join('app', 'bot', '**', '*.rb')]
+  bots_reloader = ActiveSupport::FileUpdateChecker.new(bots_files) do
+    bots_files.each{ |file| require_dependency file }
   end
   ActionDispatch::Callbacks.to_prepare do
     bot_reloader.execute_if_updated
   end
 
-  bot_files.each { |file| require_dependency file }
+  bots_files.each { |file| require_dependency file }
 end
 ```
 


### PR DESCRIPTION
Hi, 

I try to let Rails auto reload files in `app/bot` and I found `FileUpdateChecker` in [grape](https://github.com/ruby-grape/grape#reloading-in-rails-applications) README.

I update README to use same way to let bot files can reload by Rails without restart server.