### PR TITLE
Fix suggested directory for rails apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,10 @@ Rails.application.routes.draw do
 end
 ```
 
-We suggest that you put your bot code in `app/bot`.
+We suggest that you put your bot code in `app/bots`.
 
 ```ruby
-# app/bot/example.rb
+# app/bots/example.rb
 
 include Facebook::Messenger
 
@@ -351,7 +351,7 @@ unless Rails.env.production?
   bots_reloader = ActiveSupport::FileUpdateChecker.new(bot_files) do
     bot_files.each{ |file| require_dependency file }
   end
-  
+
   ActionDispatch::Callbacks.to_prepare do
     bots_reloader.execute_if_updated
   end


### PR DESCRIPTION
The suggested directory for rails apps has a typo. Update from `app/bot` to `app/bots` to follow the configurations set in the rest of the readme.

![screenshot from 2016-09-18 00-40-37](https://cloud.githubusercontent.com/assets/8701333/18613956/b96854d6-7d39-11e6-924f-bd9acdac3c71.png)
