### PR TITLE
Fix error when events does not contain a message

### DIFF
--- a/lib/facebook/messenger/server.rb
+++ b/lib/facebook/messenger/server.rb
@@ -130,8 +130,10 @@ module Facebook
         events['entry'.freeze].each do |entry|
           # Facebook may batch several items in the 'messaging' array during
           # periods of high load.
-          entry['messaging'.freeze].each do |messaging|
-            Facebook::Messenger::Bot.receive(messaging)
+          if entry['messaging'.freeze].present?
+            entry['messaging'.freeze].each do |messaging|
+              Facebook::Messenger::Bot.receive(messaging)
+            end
           end
         end
       end


### PR DESCRIPTION
events['entry'] may not always contain a message. I have been facing trouble with this thing and fixed it the following way. If I am missing anything here, please tell me. 