### PR TITLE
Added a default status 200 for incoming requests from facebook

### DIFF
--- a/lib/facebook/messenger/server.rb
+++ b/lib/facebook/messenger/server.rb
@@ -22,6 +22,8 @@ module Facebook
       def call(env)
         @request = Rack::Request.new(env)
         @response = Rack::Response.new
+        # By default, send a 200 to Facebook to let them know we received the message correctly
+        @response.status = 200 
 
         if @request.get?
           verify


### PR DESCRIPTION
The 200 is required to let facebook know we received the message and we are processing it. Without the 200, your bot is sometimes flooded by repeated requests from Facebook for the same message.