### PR TITLE
Return nil when calling referral on postback when referral is not set

### DIFF
--- a/lib/facebook/messenger/incoming/postback.rb
+++ b/lib/facebook/messenger/incoming/postback.rb
@@ -12,7 +12,7 @@ module Facebook
         def referral
           @referral ||= Referral::Referral.new(
             @messaging['postback']['referral']
-          )
+          ) unless @messaging['postback']['referral'].nil?
         end
       end
     end

--- a/spec/facebook/messenger/incoming/postback_spec.rb
+++ b/spec/facebook/messenger/incoming/postback_spec.rb
@@ -69,5 +69,26 @@ describe Facebook::Messenger::Incoming::Postback do
         payload['postback']['referral']['type']
       )
     end
+
+    context 'when referral is not set' do
+      let :payload do
+        {
+          'sender' => {
+            'id' => '3'
+          },
+          'recipient' => {
+            'id' => '3'
+          },
+          'timestamp' => 145_776_419_762_7,
+          'postback' => {
+            'payload' => 'USER_DEFINED_PAYLOAD'
+          }
+        }
+      end
+
+      it 'returns nil' do
+        expect(subject.referral).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi, so I ran into to an issue with postbacks and referrals. When there's no referral set from Facebook in the postback, the referral in the postback object returned another Referral object. 
This makes it hard to distinguish normal postbacks from m.me-referrals. Let me know, if i'm missing something. 