### PR TITLE
Fix Sender-API

### DIFF
--- a/lib/facebook/messenger/incoming/common.rb
+++ b/lib/facebook/messenger/incoming/common.rb
@@ -21,10 +21,28 @@ module Facebook
           Time.at(@messaging['timestamp'] / 1000)
         end
 
-        def type
+        def typing_on
           payload = {
             recipient: sender,
             sender_action: 'typing_on'
+          }
+
+          Facebook::Messenger::Bot.deliver(payload, access_token: access_token)
+        end
+
+        def typing_off
+          payload = {
+            recipient: sender,
+            sender_action: 'typing_off'
+          }
+
+          Facebook::Messenger::Bot.deliver(payload, access_token: access_token)
+        end
+
+        def mark_seen
+          payload = {
+            recipient: sender,
+            sender_action: 'mark_seen'
           }
 
           Facebook::Messenger::Bot.deliver(payload, access_token: access_token)

--- a/spec/facebook/messenger/incoming/common_spec.rb
+++ b/spec/facebook/messenger/incoming/common_spec.rb
@@ -52,7 +52,7 @@ describe Dummy do
     end
   end
 
-  describe '.type' do
+  describe '.typing_on' do
     let(:access_token) { 'access_token' }
 
     it 'sends a typing indicator to the sender' do
@@ -66,7 +66,43 @@ describe Dummy do
                 sender_action: 'typing_on'
               }, access_token: access_token)
 
-      subject.type
+      subject.typing_on
+    end
+  end
+
+  describe '.typing_off' do
+    let(:access_token) { 'access_token' }
+
+    it 'sends a typing off indicator to the sender' do
+      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
+        .with(subject.recipient)
+        .and_return(access_token)
+
+      expect(Facebook::Messenger::Bot).to receive(:deliver)
+        .with({
+                recipient: subject.sender,
+                sender_action: 'typing_off'
+              }, access_token: access_token)
+
+      subject.typing_off
+    end
+  end
+
+  describe '.mark_seen' do
+    let(:access_token) { 'access_token' }
+
+    it 'sends a typing off indicator to the sender' do
+      expect(Facebook::Messenger.config.provider).to receive(:access_token_for)
+        .with(subject.recipient)
+        .and_return(access_token)
+
+      expect(Facebook::Messenger::Bot).to receive(:deliver)
+        .with({
+                recipient: subject.sender,
+                sender_action: 'mark_seen'
+              }, access_token: access_token)
+
+      subject.mark_seen
     end
   end
 


### PR DESCRIPTION
Fixes #106 

Renamed `type` into `typing_on`
Added `typing_off` and `mark_seen` to comply with the sender API

https://developers.facebook.com/docs/messenger-platform/send-api-reference/sender-actions