### PR TITLE
Update CHANGELOG for 0.11.1 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## UNRELEASED
+## [0.11.1] - 2016-11-23
 ### Fixed
 - Webhooks that don't have messaging will now be ignored rather than crash.
 - Refactored use of `dig` for compatibility with Ruby < 2.3.


### PR DESCRIPTION
I was a little confused when checked the CHANGELOG and didn't find the `0.11.1` release since it was the current version of `facebook-messenger` on my app. I believe the CHANGELOG is outdated and this PR fixes it.