### PR TITLE
Setting greeting text for different locales

### DIFF
--- a/lib/facebook/messenger/thread.rb
+++ b/lib/facebook/messenger/thread.rb
@@ -15,7 +15,7 @@ module Facebook
       module_function
 
       def set(settings, access_token:)
-        response = post '/thread_settings', body: settings.to_json, query: {
+        response = post '/messenger_profile', body: settings.to_json, query: {
           access_token: access_token
         }
 
@@ -25,7 +25,7 @@ module Facebook
       end
 
       def unset(settings, access_token:)
-        response = delete '/thread_settings', body: settings.to_json, query: {
+        response = delete '/messenger_profile', body: settings.to_json, query: {
           access_token: access_token
         }
 

--- a/spec/facebook/messenger/thread_spec.rb
+++ b/spec/facebook/messenger/thread_spec.rb
@@ -4,7 +4,7 @@ describe Facebook::Messenger::Thread do
   let(:access_token) { 'access token' }
 
   let(:thread_settings_url) do
-    Facebook::Messenger::Thread.base_uri + '/thread_settings'
+    Facebook::Messenger::Thread.base_uri + '/messenger_profile'
   end
 
   before do


### PR DESCRIPTION
According to the documentation it should be possible to set the greeting text for different locales:
https://developers.facebook.com/docs/messenger-platform/messenger-profile/greeting-text

Example:
Facebook::Messenger::Thread.set({
  setting_type: 'greeting',
  greeting: [
     { locale: 'de_DE', text: 'Welcome to your new bot overlord!' }
   ],
}, access_token: ENV['ACCESS_TOKEN'])

This leads to this error:
/thread.rb:38:in `raise_errors': (#100) Invalid keys "0" were found in param "greeting". (Facebook::Messenger::Thread::Error)

I noticed that the gem is using "/thread_settings" and not "/messenger_profile" as path. Maybe this should be changed to match the documentation.