### PR TITLE
Messenger profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ end
 Show the human you are preparing a message for them:
 
 ```ruby
-Bot.on :message do |message|  
+Bot.on :message do |message|
   message.typing_on
 
   # Do something expensive
@@ -137,7 +137,7 @@ end
 Or that you changed your mind:
 
 ```ruby
-Bot.on :message do |message|  
+Bot.on :message do |message|
   message.typing_on
 
   if # something
@@ -204,16 +204,22 @@ Bot.on :referral do |referral|
 end
 ```
 
-#### Change thread settings
+#### Change messenger profile
 
-You can greet new humans to entice them into talking to you:
+You can greet new humans to entice them into talking to you, in different locales:
 
 ```ruby
-Facebook::Messenger::Thread.set({
-  setting_type: 'greeting',
-  greeting: {
-    text: 'Welcome to your new bot overlord!'
-  },
+Facebook::Messenger::Profile.set({
+  greeting: [
+    {
+      locale: "default",
+      text: "Welcome to your new bot overlord!"
+    },
+    {
+      locale: "fr_FR",
+      text: "Bienvenue dans le bot du Wagon !"
+    }
+  ]
 }, access_token: ENV['ACCESS_TOKEN'])
 ```
 
@@ -221,38 +227,54 @@ You can define the action to trigger when new humans click on the Get
 Started button. Before doing it you should check to select the messaging_postbacks field when setting up your webhook.
 
 ```ruby
-Facebook::Messenger::Thread.set({
-  setting_type: 'call_to_actions',
-  thread_state: 'new_thread',
-  call_to_actions: [
-    {
-      payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_WELCOME'
-    }
-  ]
+Facebook::Messenger::Profile.set({
+  get_started: {
+    payload: "GET_STARTED_PAYLOAD"
+  }
 }, access_token: ENV['ACCESS_TOKEN'])
 ```
 
 You can show a persistent menu to humans.
 
 ```ruby
-Facebook::Messenger::Thread.set({
-  setting_type: 'call_to_actions',
-  thread_state: 'existing_thread',
-  call_to_actions: [
+Facebook::Messenger::Profile.set({
+  persistent_menu: [
     {
-      type: 'postback',
-      title: 'Help',
-      payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_HELP'
+      locale: "default",
+      composer_input_disabled: true,
+      call_to_actions: [
+        {
+          title: "My Account",
+          type: "nested",
+          call_to_actions: [
+            {
+              title: "What's a chatbot?",
+              type: "postback",
+              payload: "EXTERMINATE"
+            },
+            {
+              title: "History",
+              type: "postback",
+              payload: "HISTORY_PAYLOAD"
+            },
+            {
+              title: "Contact Info",
+              type: "postback",
+              payload: "CONTACT_INFO_PAYLOAD"
+            }
+          ]
+        },
+        {
+          type: "web_url",
+          title: "Get some help",
+          url: "https://github.com/hyperoslo/facebook-messenger",
+          webview_height_ratio: "full"
+        }
+      ]
     },
     {
-      type: 'postback',
-      title: 'Start a New Order',
-      payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_START_ORDER'
-    },
-    {
-      type: 'web_url',
-      title: 'View Website',
-      url: 'http://example.com/'
+      locale: "zh_CN",
+      composer_input_disabled: false
     }
   ]
 }, access_token: ENV['ACCESS_TOKEN'])

--- a/README.md
+++ b/README.md
@@ -212,12 +212,12 @@ You can greet new humans to entice them into talking to you, in different locale
 Facebook::Messenger::Profile.set({
   greeting: [
     {
-      locale: "default",
-      text: "Welcome to your new bot overlord!"
+      locale: 'default',
+      text: 'Welcome to your new bot overlord!'
     },
     {
-      locale: "fr_FR",
-      text: "Bienvenue dans le bot du Wagon !"
+      locale: 'fr_FR',
+      text: 'Bienvenue dans le bot du Wagon !'
     }
   ]
 }, access_token: ENV['ACCESS_TOKEN'])
@@ -229,7 +229,7 @@ Started button. Before doing it you should check to select the messaging_postbac
 ```ruby
 Facebook::Messenger::Profile.set({
   get_started: {
-    payload: "GET_STARTED_PAYLOAD"
+    payload: 'GET_STARTED_PAYLOAD'
   }
 }, access_token: ENV['ACCESS_TOKEN'])
 ```
@@ -240,40 +240,40 @@ You can show a persistent menu to humans.
 Facebook::Messenger::Profile.set({
   persistent_menu: [
     {
-      locale: "default",
+      locale: 'default',
       composer_input_disabled: true,
       call_to_actions: [
         {
-          title: "My Account",
-          type: "nested",
+          title: 'My Account',
+          type: 'nested',
           call_to_actions: [
             {
-              title: "What's a chatbot?",
-              type: "postback",
-              payload: "EXTERMINATE"
+              title: 'What's a chatbot?',
+              type: 'postback',
+              payload: 'EXTERMINATE'
             },
             {
-              title: "History",
-              type: "postback",
-              payload: "HISTORY_PAYLOAD"
+              title: 'History',
+              type: 'postback',
+              payload: 'HISTORY_PAYLOAD'
             },
             {
-              title: "Contact Info",
-              type: "postback",
-              payload: "CONTACT_INFO_PAYLOAD"
+              title: 'Contact Info',
+              type: 'postback',
+              payload: 'CONTACT_INFO_PAYLOAD'
             }
           ]
         },
         {
-          type: "web_url",
-          title: "Get some help",
-          url: "https://github.com/hyperoslo/facebook-messenger",
-          webview_height_ratio: "full"
+          type: 'web_url',
+          title: 'Get some help',
+          url: 'https://github.com/hyperoslo/facebook-messenger',
+          webview_height_ratio: 'full'
         }
       ]
     },
     {
-      locale: "zh_CN",
+      locale: 'zh_CN',
       composer_input_disabled: false
     }
   ]

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require 'rspec/core/rake_task'
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
-task default: %i(rubocop spec)
+task default: %i[rubocop spec]

--- a/lib/facebook/messenger.rb
+++ b/lib/facebook/messenger.rb
@@ -1,7 +1,7 @@
 require 'facebook/messenger/version'
 require 'facebook/messenger/error'
 require 'facebook/messenger/subscriptions'
-require 'facebook/messenger/thread'
+require 'facebook/messenger/profile'
 require 'facebook/messenger/bot'
 require 'facebook/messenger/server'
 require 'facebook/messenger/configuration'

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -9,9 +9,9 @@ module Facebook
 
       base_uri 'https://graph.facebook.com/v2.6/me'
 
-      EVENTS = %i(
+      EVENTS = %i[
         message delivery postback optin read account_linking referral
-      ).freeze
+      ].freeze
 
       class << self
         # Deliver a message with the given payload.

--- a/lib/facebook/messenger/profile.rb
+++ b/lib/facebook/messenger/profile.rb
@@ -2,10 +2,10 @@ require 'httparty'
 
 module Facebook
   module Messenger
-    # This module handles changing thread settings.
+    # This module handles changing messenger profile (persistent_menu, get_started and greeting).
     #
-    # https://developers.facebook.com/docs/messenger-platform/thread-settings
-    module Thread
+    # https://developers.facebook.com/docs/messenger-platform/messenger-profile
+    module Profile
       include HTTParty
 
       base_uri 'https://graph.facebook.com/v2.6/me'
@@ -15,7 +15,7 @@ module Facebook
       module_function
 
       def set(settings, access_token:)
-        response = post '/thread_settings', body: settings.to_json, query: {
+        response = post '/messenger_profile', body: settings.to_json, query: {
           access_token: access_token
         }
 
@@ -25,7 +25,7 @@ module Facebook
       end
 
       def unset(settings, access_token:)
-        response = delete '/thread_settings', body: settings.to_json, query: {
+        response = delete '/messenger_profile', body: settings.to_json, query: {
           access_token: access_token
         }
 

--- a/lib/facebook/messenger/profile.rb
+++ b/lib/facebook/messenger/profile.rb
@@ -2,7 +2,7 @@ require 'httparty'
 
 module Facebook
   module Messenger
-    # This module handles changing messenger profile (persistent_menu, get_started and greeting).
+    # This module handles changing messenger profile (menu, start & greeting).
     #
     # https://developers.facebook.com/docs/messenger-platform/messenger-profile
     module Profile

--- a/spec/facebook/messenger/thread_spec.rb
+++ b/spec/facebook/messenger/thread_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Facebook::Messenger::Thread do
+describe Facebook::Messenger::Profile do
   let(:access_token) { 'access token' }
 
-  let(:thread_settings_url) do
-    Facebook::Messenger::Thread.base_uri + '/thread_settings'
+  let(:messenger_profile_url) do
+    Facebook::Messenger::Profile.base_uri + '/messenger_profile'
   end
 
   before do
@@ -14,7 +14,7 @@ describe Facebook::Messenger::Thread do
   describe '.set' do
     context 'with a successful response' do
       before do
-        stub_request(:post, thread_settings_url)
+        stub_request(:post, messenger_profile_url)
           .with(
             query: {
               access_token: access_token
@@ -23,14 +23,14 @@ describe Facebook::Messenger::Thread do
               'Content-Type' => 'application/json'
             },
             body: JSON.dump(
-              setting_type: 'call_to_actions',
-              thread_state: 'new_thread',
-              call_to_actions: [{ payload: 'USER_DEFINED_PAYLOAD' }]
+              get_started: {
+                payload: "GET_STARTED_PAYLOAD"
+              }
             )
           )
           .to_return(
             body: JSON.dump(
-              result: "Successfully added new thread's CTAs"
+              result: "Successfully added Get Started button"
             ),
             status: 200,
             headers: default_graph_api_response_headers
@@ -39,9 +39,9 @@ describe Facebook::Messenger::Thread do
 
       let :options do
         {
-          setting_type: 'call_to_actions',
-          thread_state: 'new_thread',
-          call_to_actions: [{ payload: 'USER_DEFINED_PAYLOAD' }]
+          get_started: {
+            payload: "GET_STARTED_PAYLOAD"
+          }
         }
       end
 
@@ -54,7 +54,7 @@ describe Facebook::Messenger::Thread do
       let(:error_message) { 'Invalid OAuth access token.' }
 
       before do
-        stub_request(:post, thread_settings_url)
+        stub_request(:post, messenger_profile_url)
           .with(query: { access_token: access_token })
           .to_return(
             body: JSON.dump(
@@ -73,14 +73,14 @@ describe Facebook::Messenger::Thread do
       it 'raises an error' do
         expect do
           options = {
-            setting_type: 'call_to_actions',
-            thread_state: 'new_thread',
-            call_to_actions: [{ payload: 'USER_DEFINED_PAYLOAD' }]
+            get_started: {
+              payload: "GET_STARTED_PAYLOAD"
+            }
           }
 
           subject.set(options, access_token: access_token)
         end.to raise_error(
-          Facebook::Messenger::Thread::Error, error_message
+          Facebook::Messenger::Profile::Error, error_message
         )
       end
     end
@@ -89,7 +89,7 @@ describe Facebook::Messenger::Thread do
   describe '.unset' do
     context 'with a successful response' do
       before do
-        stub_request(:delete, thread_settings_url)
+        stub_request(:delete, messenger_profile_url)
           .with(
             query: {
               access_token: access_token
@@ -98,13 +98,14 @@ describe Facebook::Messenger::Thread do
               'Content-Type' => 'application/json'
             },
             body: JSON.dump(
-              setting_type: 'call_to_actions',
-              thread_state: 'new_thread'
+              fields: [
+                "get_started"
+              ]
             )
           )
           .to_return(
             body: JSON.dump(
-              result: "Successfully added new thread's CTAs"
+              result: "Successfully deleted Get Started button"
             ),
             status: 200,
             headers: default_graph_api_response_headers
@@ -113,8 +114,9 @@ describe Facebook::Messenger::Thread do
 
       let :options do
         {
-          setting_type: 'call_to_actions',
-          thread_state: 'new_thread'
+          fields: [
+            "get_started"
+          ]
         }
       end
 
@@ -127,7 +129,7 @@ describe Facebook::Messenger::Thread do
       let(:error_message) { 'Invalid OAuth access token.' }
 
       before do
-        stub_request(:delete, thread_settings_url)
+        stub_request(:delete, messenger_profile_url)
           .with(query: { access_token: access_token })
           .to_return(
             body: JSON.dump(
@@ -146,12 +148,13 @@ describe Facebook::Messenger::Thread do
       it 'raises an error' do
         expect do
           options = {
-            setting_type: 'call_to_actions',
-            thread_state: 'new_thread'
+            fields: [
+              "get_started"
+            ]
           }
           subject.unset(options, access_token: access_token)
         end.to raise_error(
-          Facebook::Messenger::Thread::Error, error_message
+          Facebook::Messenger::Profile::Error, error_message
         )
       end
     end

--- a/spec/facebook/messenger/thread_spec.rb
+++ b/spec/facebook/messenger/thread_spec.rb
@@ -24,13 +24,13 @@ describe Facebook::Messenger::Profile do
             },
             body: JSON.dump(
               get_started: {
-                payload: "GET_STARTED_PAYLOAD"
+                payload: 'GET_STARTED_PAYLOAD'
               }
             )
           )
           .to_return(
             body: JSON.dump(
-              result: "Successfully added Get Started button"
+              result: 'Successfully added Get Started button'
             ),
             status: 200,
             headers: default_graph_api_response_headers
@@ -40,7 +40,7 @@ describe Facebook::Messenger::Profile do
       let :options do
         {
           get_started: {
-            payload: "GET_STARTED_PAYLOAD"
+            payload: 'GET_STARTED_PAYLOAD'
           }
         }
       end
@@ -74,7 +74,7 @@ describe Facebook::Messenger::Profile do
         expect do
           options = {
             get_started: {
-              payload: "GET_STARTED_PAYLOAD"
+              payload: 'GET_STARTED_PAYLOAD'
             }
           }
 
@@ -99,13 +99,13 @@ describe Facebook::Messenger::Profile do
             },
             body: JSON.dump(
               fields: [
-                "get_started"
+                'get_started'
               ]
             )
           )
           .to_return(
             body: JSON.dump(
-              result: "Successfully deleted Get Started button"
+              result: 'Successfully deleted Get Started button'
             ),
             status: 200,
             headers: default_graph_api_response_headers
@@ -115,7 +115,7 @@ describe Facebook::Messenger::Profile do
       let :options do
         {
           fields: [
-            "get_started"
+            'get_started'
           ]
         }
       end
@@ -149,7 +149,7 @@ describe Facebook::Messenger::Profile do
         expect do
           options = {
             fields: [
-              "get_started"
+              'get_started'
             ]
           }
           subject.unset(options, access_token: access_token)


### PR DESCRIPTION
Hello, I changed thread_settings to messenger_profile, due to deprecation in Send API 1.4, and especially introduction of nesting in Persistent menus.