### PR TITLE
Add method to fetch app_id in case of message echo

### DIFF
--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -25,6 +25,10 @@ module Facebook
           @messaging['message']['attachments']
         end
 
+        def app_id
+          @messaging['message']['app_id']
+        end
+
         def quick_reply
           return unless @messaging['message']['quick_reply']
 

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -12,6 +12,7 @@ describe Facebook::Messenger::Incoming::Message do
       'timestamp' => 145_776_419_762_7,
       'message' => {
         'is_echo' => false,
+        'app_id' => 184719329217930000,
         'mid' => 'mid.1457764197618:41d102a3e1ae206a38',
         'seq' => 73,
         'text' => 'Hello, bot!',
@@ -81,6 +82,12 @@ describe Facebook::Messenger::Incoming::Message do
   describe '.attachments' do
     it 'returns the message attachments' do
       expect(subject.attachments).to eq(payload['message']['attachments'])
+    end
+  end
+
+  describe '.app_id' do
+    it 'returns the app_id from which the message was sent' do
+      expect(subject.app_id).to eq(payload['message']['app_id'])
     end
   end
 

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -12,7 +12,7 @@ describe Facebook::Messenger::Incoming::Message do
       'timestamp' => 145_776_419_762_7,
       'message' => {
         'is_echo' => false,
-        'app_id' => 184719329217930000,
+        'app_id' => 184_719_329_217_930_000,
         'mid' => 'mid.1457764197618:41d102a3e1ae206a38',
         'seq' => 73,
         'text' => 'Hello, bot!',


### PR DESCRIPTION
Facebook Webhooks API now sends `
ID of the app from which the message was sent` as app_id in the payload.
Adding a method to fetch this id from payload.

More info: https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-echo