### PR TITLE
Adding helpers for attachments

### DIFF
--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -38,6 +38,7 @@ module Facebook
         end
 
         def attachment_type
+          return nil if attachments == nil
           attachments.first['type']
         end
 
@@ -45,14 +46,16 @@ module Facebook
           return nil if attachments == nil
           if ['image', 'audio', 'video', 'file'].include? attachment_type
             url = attachments.first['payload']['url']
+          else
+            url = nil
           end
           url
         end
 
         def location_coordinates
           return [] unless attachment_type?('location')
-          coordinates_data = attachments.first['payload']['coordinates']
-          [coordinates_data['lat'], coordinates_data['long']]
+          coordinates_data = attachments.first['payload']
+          [coordinates_data['coordinates.lat'], coordinates_data['coordinates.long']]
         end
 
         def quick_reply

--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -54,8 +54,8 @@ module Facebook
 
         def location_coordinates
           return [] unless attachment_type?('location')
-          coordinates_data = attachments.first['payload']
-          [coordinates_data['coordinates.lat'], coordinates_data['coordinates.long']]
+          coordinates_data = attachments.first['payload']['coordinates']
+          [coordinates_data['lat'], coordinates_data['long']]
         end
 
         def quick_reply

--- a/lib/facebook/messenger/incoming/message.rb
+++ b/lib/facebook/messenger/incoming/message.rb
@@ -5,6 +5,8 @@ module Facebook
       class Message
         include Facebook::Messenger::Incoming::Common
 
+        ATTACHMENT_TYPES = ['image', 'audio', 'video', 'file','location','fallback']
+
         def id
           @messaging['message']['mid']
         end
@@ -29,11 +31,42 @@ module Facebook
           @messaging['message']['app_id']
         end
 
+        ATTACHMENT_TYPES.each do |attachment_type|
+          define_method "#{attachment_type}_attachment?" do
+            attachment_type?(attachment_type)
+          end
+        end
+
+        def attachment_type
+          attachments.first['type']
+        end
+
+        def attachment_url
+          return nil if attachments == nil
+          if ['image', 'audio', 'video', 'file'].include? attachment_type
+            url = attachments.first['payload']['url']
+          end
+          url
+        end
+
+        def location_coordinates
+          return [] unless attachment_type?('location')
+          coordinates_data = attachments.first['payload']['coordinates']
+          [coordinates_data['lat'], coordinates_data['long']]
+        end
+
         def quick_reply
           return unless @messaging['message']['quick_reply']
 
           @messaging['message']['quick_reply']['payload']
         end
+
+        private
+
+        def attachment_type?(attachment_type)
+          attachments != nil && attachments.first['type'] == attachment_type
+        end
+
       end
     end
   end

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -115,8 +115,10 @@ describe Facebook::Messenger::Incoming::Message do
         'attachments' => [{
           'type' => 'location',
           'payload' => {
-            'coordinates.lat' => '39.920_770',
-            'coordinates.long' => '40.920_770'
+            'coordinates' => {
+              'lat' => '39.920_770',
+              'long' => '40.920_770'
+            }
           }
         }]
       }
@@ -216,7 +218,7 @@ describe Facebook::Messenger::Incoming::Message do
   describe '.location_coordinates' do
     subject { Facebook::Messenger::Incoming::Message.new(location_payload) }
     it 'returns array of lat long coordinates' do
-      expect(subject.location_coordinates).to eq([location_payload['message']['attachments'].first['payload']['coordinates.lat'],location_payload['message']['attachments'].first['payload']['coordinates.long']])
+      expect(subject.location_coordinates).to eq([location_payload['message']['attachments'].first['payload']['coordinates']['lat'],location_payload['message']['attachments'].first['payload']['coordinates']['long']])
     end
   end
 

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -29,6 +29,100 @@ describe Facebook::Messenger::Incoming::Message do
     }
   end
 
+  let :video_payload do
+    {
+      'sender' => {
+        'id' => '5'
+      },
+      'recipient' => {
+        'id' => '7'
+      },
+      'timestamp' => 145_776_419_762_4,
+      'message' => {
+        'is_echo' => false,
+        'app_id' => 184_719_329_217_930_001,
+        'mid' => 'mid.1457764197618:41d102a3e1ae206a38',
+        'attachments' => [{
+          'type' => 'video',
+          'payload' => {
+            'url' => 'https://www.example.com/2.mp4'
+          }
+        }]
+      }
+    }
+  end
+
+  let :file_payload do
+    {
+      'sender' => {
+        'id' => '5'
+      },
+      'recipient' => {
+        'id' => '7'
+      },
+      'timestamp' => 145_776_412_762_4,
+      'message' => {
+        'is_echo' => false,
+        'app_id' => 184_719_329_217_930_001,
+        'mid' => 'mid.1457764197618:41d102a3e1ae206a39',
+        'attachments' => [{
+          'type' => 'file',
+          'payload' => {
+            'url' => 'https://www.example.com/3.pdf'
+          }
+        }]
+      }
+    }
+  end
+
+  let :audio_payload do
+    {
+      'sender' => {
+        'id' => '8'
+      },
+      'recipient' => {
+        'id' => '9'
+      },
+      'timestamp' => 145_776_419_732_4,
+      'message' => {
+        'is_echo' => false,
+        'app_id' => 184_719_329_217_930_001,
+        'mid' => 'mid.1457764197618:41d102a3e1ae206a48',
+        'attachments' => [{
+          'type' => 'audio',
+          'payload' => {
+            'url' => 'https://www.example.com/4.ogg'
+          }
+        }]
+      }
+    }
+  end
+
+
+  let :location_payload do
+    {
+      'sender' => {
+        'id' => '6'
+      },
+      'recipient' => {
+        'id' => '9'
+      },
+      'timestamp' => 145_776_429_762_4,
+      'message' => {
+        'is_echo' => false,
+        'app_id' => 184_719_329_222_930_001,
+        'mid' => 'mid.1457764197618:41d102a3e1ae206a38',
+        'attachments' => [{
+          'type' => 'location',
+          'payload' => {
+            'coordinates.lat' => '39.920_770',
+            'coordinates.long' => '40.920_770'
+          }
+        }]
+      }
+    }
+  end
+
   subject { Facebook::Messenger::Incoming::Message.new(payload) }
 
   describe '.messaging' do
@@ -88,6 +182,41 @@ describe Facebook::Messenger::Incoming::Message do
   describe '.image_attachment?' do
     it 'returns whether the attachment is an image' do
       expect(subject.image_attachment?).to eq(payload['message']['attachments'].first['type'] == 'image')
+    end
+  end
+
+  describe '.video_attachment?' do
+    subject { Facebook::Messenger::Incoming::Message.new(video_payload) }
+    it 'returns whether the attachment is a video' do
+      expect(subject.video_attachment?).to eq(video_payload['message']['attachments'].first['type'] == 'video')
+    end
+  end
+
+  describe '.location_attachment?' do
+    subject { Facebook::Messenger::Incoming::Message.new(location_payload) }
+    it 'returns whether the attachment is a video' do
+      expect(subject.location_attachment?).to eq(location_payload['message']['attachments'].first['type'] == 'location')
+    end
+  end
+
+  describe '.audio_attachment?' do
+    subject { Facebook::Messenger::Incoming::Message.new(audio_payload) }
+    it 'returns whether the attachment is an audio' do
+      expect(subject.audio_attachment?).to eq(audio_payload['message']['attachments'].first['type'] == 'audio')
+    end
+  end
+
+  describe '.file_attachment?' do
+    subject { Facebook::Messenger::Incoming::Message.new(file_payload) }
+    it 'returns whether the attachment is a file' do
+      expect(subject.file_attachment?).to eq(file_payload['message']['attachments'].first['type'] == 'file')
+    end
+  end
+
+  describe '.location_coordinates' do
+    subject { Facebook::Messenger::Incoming::Message.new(location_payload) }
+    it 'returns array of lat long coordinates' do
+      expect(subject.location_coordinates).to eq([location_payload['message']['attachments'].first['payload']['coordinates.lat'],location_payload['message']['attachments'].first['payload']['coordinates.long']])
     end
   end
 

--- a/spec/facebook/messenger/incoming/message_spec.rb
+++ b/spec/facebook/messenger/incoming/message_spec.rb
@@ -85,6 +85,23 @@ describe Facebook::Messenger::Incoming::Message do
     end
   end
 
+  describe '.image_attachment?' do
+    it 'returns whether the attachment is an image' do
+      expect(subject.image_attachment?).to eq(payload['message']['attachments'].first['type'] == 'image')
+    end
+  end
+
+  describe '.attachment_type' do
+    it 'returns the type of the attachment' do
+      expect(subject.attachment_type).to eq(payload['message']['attachments'].first['type'])
+    end
+  end
+
+  describe '.attachment_url' do
+    it 'returns the url of the attachment' do
+      expect(subject.attachment_url).to eq(payload['message']['attachments'].first['payload']['url'])
+    end
+  end
   describe '.app_id' do
     it 'returns the app_id from which the message was sent' do
       expect(subject.app_id).to eq(payload['message']['app_id'])


### PR DESCRIPTION
Added helpers to access attachments, namely:

`image_attachment?`, `file_attachment?`, `location_attachment?` , `audio_attachment?`, `video_attachment?`, `fallback_attachment?` - to check the type of attachment.

`attachment_type` - to get the type of attachment present, eg 'file' or 'audio'

`attachment_url` - to get the url of the attachment present

`location_coordinates ` - to get the lat and long coordinates if the attachment type is location

@jgorset please advise on how to add tests for `location_coordinates` method. Do I need to create a new payload in the spec, because and image_attachment and location attachment won't be coming together in response.