### PR TITLE
Update to Graph API v20.0 and add new comment sending method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [2.1.2] - 2024-07-18
+
+### Changed
+- Updated to Graph API v20.0
+
+### Added
+- New method for sending comments in Bot module
+
+## [2.0.2] - 2024-03-20
+
+### Added
+- Support for feed events
+- Support for leadgen events
+- Standby entry for fb messenger
+
 ## [2.0.1] - 2020-07-31
 
 ### Changed

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -13,7 +13,7 @@ module Facebook
       include HTTParty
 
       # Define base_uri for HTTParty.
-      base_uri 'https://graph.facebook.com/v3.2'
+      base_uri 'https://graph.facebook.com/v20.0'
 
       #
       # @return [Array] Array containing the supported webhook events.
@@ -65,7 +65,7 @@ module Facebook
         end
 
         # Reply to a Facebook comment.
-        # @see https://developers.facebook.com/docs/graph-api/reference/v3.2/object/comments
+        # @see https://developers.facebook.com/docs/graph-api/reference/v20.0/object/comments
         #
         # @raise [Facebook::Messenger::Bot::SendError] if there is any error
         #   in response while sending the comment.

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -32,6 +32,7 @@ module Facebook
         game_play
         reaction
         feed
+        leadgen
       ].freeze
 
       class << self

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -31,6 +31,7 @@ module Facebook
         pass_thread_control
         game_play
         reaction
+        feed
       ].freeze
 
       class << self

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -13,7 +13,7 @@ module Facebook
       include HTTParty
 
       # Define base_uri for HTTParty.
-      base_uri 'https://graph.facebook.com/v3.2/me'
+      base_uri 'https://graph.facebook.com/v3.2'
 
       #
       # @return [Array] Array containing the supported webhook events.
@@ -54,7 +54,35 @@ module Facebook
           query = { access_token: access_token }
           query[:appsecret_proof] = app_secret_proof if app_secret_proof
 
-          response = post '/messages',
+          response = post '/me/messages',
+                          body: JSON.dump(message),
+                          format: :json,
+                          query: query
+
+          Facebook::Messenger::Bot::ErrorParser.raise_errors_from(response)
+
+          response.body
+        end
+
+        # Reply to a Facebook comment.
+        # @see https://developers.facebook.com/docs/graph-api/reference/v3.2/object/comments
+        #
+        # @raise [Facebook::Messenger::Bot::SendError] if there is any error
+        #   in response while sending the comment.
+        #
+        # @param [Hash] comment The comment payload
+        # @param [String] page_id The page ID to send the comment from
+        #
+        # Returns a Hash describing the API response if the comment was sent,
+        # or raises an exception if it was not.
+        def reply_to_comment(comment_id, message, page_id:)
+          access_token = config.provider.access_token_for(page_id)
+          app_secret_proof = config.provider.app_secret_proof_for(page_id)
+
+          query = { access_token: access_token }
+          query[:appsecret_proof] = app_secret_proof if app_secret_proof
+
+          response = post "/#{comment_id}/comments",
                           body: JSON.dump(message),
                           format: :json,
                           query: query

--- a/lib/facebook/messenger/incoming.rb
+++ b/lib/facebook/messenger/incoming.rb
@@ -13,6 +13,8 @@ require 'facebook/messenger/incoming/policy_enforcement'
 require 'facebook/messenger/incoming/pass_thread_control'
 require 'facebook/messenger/incoming/game_play'
 require 'facebook/messenger/incoming/message_reaction'
+require 'facebook/messenger/incoming/feed_common'
+require 'facebook/messenger/incoming/feed'
 
 module Facebook
   module Messenger
@@ -37,7 +39,8 @@ module Facebook
         'policy_enforcement' => PolicyEnforcement,
         'pass_thread_control' => PassThreadControl,
         'game_play' => GamePlay,
-        'reaction' => MessageReaction
+        'reaction' => MessageReaction,
+        'feed' => Feed,
       }.freeze
 
       # Parse the given payload and create new object of class related
@@ -54,7 +57,7 @@ module Facebook
         return MessageEcho.new(payload) if payload_is_echo?(payload)
 
         EVENTS.each do |event, klass|
-          return klass.new(payload) if payload.key?(event)
+          return klass.new(payload) if payload.key?(event) || payload['field'] == event
         end
 
         raise UnknownPayload, payload

--- a/lib/facebook/messenger/incoming.rb
+++ b/lib/facebook/messenger/incoming.rb
@@ -15,6 +15,7 @@ require 'facebook/messenger/incoming/game_play'
 require 'facebook/messenger/incoming/message_reaction'
 require 'facebook/messenger/incoming/feed_common'
 require 'facebook/messenger/incoming/feed'
+require 'facebook/messenger/incoming/leadgen'
 
 module Facebook
   module Messenger
@@ -41,6 +42,7 @@ module Facebook
         'game_play' => GamePlay,
         'reaction' => MessageReaction,
         'feed' => Feed,
+        'leadgen' => Leadgen,
       }.freeze
 
       # Parse the given payload and create new object of class related

--- a/lib/facebook/messenger/incoming/feed.rb
+++ b/lib/facebook/messenger/incoming/feed.rb
@@ -1,0 +1,16 @@
+module Facebook
+  module Messenger
+    module Incoming
+      class Feed
+        include Facebook::Messenger::Incoming::FeedCommon
+
+        def id
+          @change['value']['post_id']
+        end
+        def message
+          @change['value']['message']
+        end
+      end
+    end
+  end
+end

--- a/lib/facebook/messenger/incoming/feed_common.rb
+++ b/lib/facebook/messenger/incoming/feed_common.rb
@@ -1,0 +1,17 @@
+module Facebook
+  module Messenger
+    module Incoming
+      module FeedCommon
+        attr_reader :change
+
+        def initialize(change)
+          @change = change
+        end
+
+        def item
+          @change['item']
+        end
+      end
+    end
+  end
+end

--- a/lib/facebook/messenger/incoming/leadgen.rb
+++ b/lib/facebook/messenger/incoming/leadgen.rb
@@ -1,0 +1,13 @@
+module Facebook
+  module Messenger
+    module Incoming
+      class Leadgen
+        include Facebook::Messenger::Incoming::FeedCommon
+
+        def id
+          @change['value']['leadgen_id']
+        end
+      end
+    end
+  end
+end

--- a/lib/facebook/messenger/profile.rb
+++ b/lib/facebook/messenger/profile.rb
@@ -10,7 +10,7 @@ module Facebook
       include HTTParty
 
       # Define base_uri for HTTParty.
-      base_uri 'https://graph.facebook.com/v3.2/me'
+      base_uri 'https://graph.facebook.com/v20.0/me'
 
       format :json
 

--- a/lib/facebook/messenger/server.rb
+++ b/lib/facebook/messenger/server.rb
@@ -144,8 +144,8 @@ module Facebook
       #
       def parsed_body
         @parsed_body ||= JSON.parse(body)
-      rescue JSON::ParserError
-        raise BadRequestError, 'Error parsing request body format'
+      rescue JSON::ParserError => error
+        raise BadRequestError, error
       end
 
       #
@@ -170,6 +170,13 @@ module Facebook
               Facebook::Messenger::Bot.receive(change)
             end
           end
+          # d99d
+          if entry['standby'.freeze]
+            entry['standby'.freeze].each do |messaging|
+              Facebook::Messenger::Bot.receive(messaging)
+            end
+          end
+          # .
         end
       end
 

--- a/lib/facebook/messenger/server.rb
+++ b/lib/facebook/messenger/server.rb
@@ -157,14 +157,18 @@ module Facebook
         # Facebook may batch several items in the 'entry' array during
         # periods of high load.
         events['entry'.freeze].each do |entry|
-          # If the application has subscribed to webhooks other than Messenger,
-          # 'messaging' won't be available and it is not relevant to us.
-          next unless entry['messaging'.freeze]
 
           # Facebook may batch several items in the 'messaging' array during
           # periods of high load.
-          entry['messaging'.freeze].each do |messaging|
-            Facebook::Messenger::Bot.receive(messaging)
+          if entry['messaging'.freeze]
+            entry['messaging'.freeze].each do |messaging|
+              Facebook::Messenger::Bot.receive(messaging)
+            end
+          end
+          if entry['changes'.freeze]
+            entry['changes'.freeze].each do |change|
+              Facebook::Messenger::Bot.receive(change)
+            end
           end
         end
       end

--- a/lib/facebook/messenger/subscriptions.rb
+++ b/lib/facebook/messenger/subscriptions.rb
@@ -9,7 +9,7 @@ module Facebook
     module Subscriptions
       include HTTParty
 
-      base_uri 'https://graph.facebook.com/v3.2/me'
+      base_uri 'https://graph.facebook.com/v20.0/me'
 
       format :json
 

--- a/lib/facebook/messenger/version.rb
+++ b/lib/facebook/messenger/version.rb
@@ -2,6 +2,6 @@ module Facebook
   module Messenger
     #
     # @return [String] Define the version of gem.
-    VERSION = '2.0.1'.freeze
+    VERSION = '2.0.2'.freeze
   end
 end

--- a/lib/facebook/messenger/version.rb
+++ b/lib/facebook/messenger/version.rb
@@ -2,6 +2,6 @@ module Facebook
   module Messenger
     #
     # @return [String] Define the version of gem.
-    VERSION = '2.0.2'.freeze
+    VERSION = '2.1.2'.freeze
   end
 end

--- a/spec/facebook/messenger/incoming/feed_common_spec.rb
+++ b/spec/facebook/messenger/incoming/feed_common_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+class Dummy2
+  include Facebook::Messenger::Incoming::FeedCommon
+end
+
+payload = JSON.parse({
+  "value": {
+    "from": {
+      "id": "100518329516574",
+      "name": "Vit Service"
+    },
+    "message": "post 7",
+    "post_id": "100518329516574_193994006819374",
+    "created_time": 1682932701,
+    "item": "status",
+    "published": 1,
+    "verb": "add"
+  },
+  "field": "feed"
+}.to_json)
+
+describe Dummy2 do
+  subject { Dummy2.new(payload) }
+
+  describe '.item' do
+    it 'returns the item' do
+      expect(subject.item).to eq(payload['item'])
+    end
+  end
+
+end

--- a/spec/facebook/messenger/incoming/feed_spec.rb
+++ b/spec/facebook/messenger/incoming/feed_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Facebook::Messenger::Incoming::Feed do
+  let :payload do
+     JSON.parse({
+        "value": {
+            "from": {
+                "id": "100518329516574",
+                "name": "Vit Service"
+            },
+            "message": "post 8",
+            "post_id": "100518329516574_194260390126069",
+            "created_time": 1682963527,
+            "item": "status",
+            "published": 1,
+            "verb": "add"
+        },
+        "field": "feed"
+    }.to_json)
+  end
+
+
+  subject { Facebook::Messenger::Incoming::Feed.new(payload) }
+
+  describe '.changes' do
+    it 'returns the original payload' do
+      expect(subject.change).to eq(payload)
+    end
+  end
+
+  describe '.id' do
+    it 'returns the message id' do
+      expect(subject.id).to eq(payload['value']['post_id'])
+    end
+  end
+
+end

--- a/spec/facebook/messenger/incoming/leadgen_spec.rb
+++ b/spec/facebook/messenger/incoming/leadgen_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Facebook::Messenger::Incoming::Leadgen do
+  let :payload do
+     JSON.parse({
+          "value": {
+            "created_time": 1683790226,
+            "leadgen_id": "798522598540294",
+            "page_id": "119324881085321",
+            "form_id": "172197529124035"
+          },
+          "field": "leadgen"
+    }.to_json)
+  end
+
+  subject { Facebook::Messenger::Incoming::Leadgen.new(payload) }
+
+  describe '.changes' do
+    it 'returns the original payload' do
+      expect(subject.change).to eq(payload)
+    end
+  end
+
+  describe '.id' do
+    it 'returns the message id' do
+      expect(subject.id).to eq(payload['value']['leadgen_id'])
+    end
+  end
+
+end

--- a/spec/facebook/messenger/incoming_spec.rb
+++ b/spec/facebook/messenger/incoming_spec.rb
@@ -16,6 +16,32 @@ describe Facebook::Messenger::Incoming do
       end
     end
 
+    context 'when the payload is a post' do
+      let :payload do
+        JSON.parse({
+          "value": {
+            "from": {
+              "id": "100518329516574",
+              "name": "Vit Service"
+            },
+            "message": "post 7",
+            "post_id": "100518329516574_193994006819374",
+            "created_time": 1682932701,
+            "item": "status",
+            "published": 1,
+            "verb": "add"
+          },
+          "field": "feed"
+        }.to_json)
+      end
+
+      it 'returns an Incoming::Feed' do
+        expect(subject.parse(payload)).to be_a(
+          Facebook::Messenger::Incoming::Feed
+        )
+      end
+    end
+
     context 'when the payload is a message' do
       let :payload do
         {

--- a/spec/facebook/messenger/subscriptions_spec.rb
+++ b/spec/facebook/messenger/subscriptions_spec.rb
@@ -29,12 +29,7 @@ describe Facebook::Messenger::Subscriptions do
       end
 
       it 'returns true' do
-        args = {
-          access_token: access_token,
-          subscribed_fields: subscribed_fields
-        }
-
-        expect(subject.subscribe(args)).to be true
+        expect(subject.subscribe(access_token: access_token,subscribed_fields: subscribed_fields)).to be true
       end
     end
 


### PR DESCRIPTION
This pull request includes the following changes:

- Updated the library to use Graph API v20.0
- Added a new method for sending comments in the Bot module
- Incorporated changes from tviv fork:
  - Added feed event support
  - Added leadgen event support
  - Added standby entry support for Facebook Messenger

These updates will:
1. Keep our library current with the latest Facebook Graph API
2. Provide additional functionality for bot interactions, including improved handling of comments on Facebook posts
3. Expand event handling capabilities
4. Improve Facebook Messenger integration

The changes from the tviv fork enhance our library's ability to handle various Facebook events, improve Messenger functionality, and provide better support for interacting with comments on Facebook posts.